### PR TITLE
ci(workflow): add minimal CI workflow

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -1,0 +1,70 @@
+name: Biome Ecosystem CI
+
+on:
+  schedule:
+    - cron: "0 5 * * 1,3,5" # monday,wednesday,friday 5AM
+
+jobs:
+  build-biome:
+    name: Build Biome
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Biome
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: biomejs/biome
+          ref: main
+
+      - name: Install toolchain
+        uses: moonrepo/setup-rust@e013866c4215f77c925f42f60257dec7dd18836e # v1.2.1
+        with:
+          cache-target: release
+          cache-base: main
+
+      - name: Build Biome binary
+        env:
+          RUSTFLAGS: "-C debug-assertions=true"
+        run: cargo build -p biome_cli --release
+
+      - name: Upload Biome binary
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        with:
+          if-no-files-found: error
+          name: biome
+          path: ./target/release/biome
+
+  test-ecosystem:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Add projects to test here
+          - repository: preactjs/preact
+            ref: main
+            path: preact
+            command: ./biome check
+
+    name: Test ${{ matrix.repository }}
+    needs: build-biome
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ matrix.repository }}
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ matrix.repository }}
+          ref: ${{ matrix.ref }}
+          path: ${{ matrix.path }}
+
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: biome
+          path: ${{ matrix.path }}
+
+      - run: chmod +x ./biome
+        working-directory: ${{ matrix.path }}
+
+      - name: Run command
+        working-directory: ${{ matrix.path }}
+        run: ${{ matrix.command }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# ecosystem-ci
+# Ecosystem CI
+
+This repository is used to run integration tests for projects that use Biome.


### PR DESCRIPTION
Add a minimal workflow that is run every Monday, Wednesday, and Friday at 5am (this is what VIte and Vue are doing).

The workflow checkouts the biome repository (the main branch) and builds the Biome CLI in release mode keeping debug assertions enabled.
Then, we run a specified command on every listed projects. For now, I just added Preact for testing the workflow.